### PR TITLE
AMDTBackEnd: Fix VOP3 instruction decoding

### DIFF
--- a/CodeXL/Components/ShaderAnalyzer/AMDTBackEnd/Emulator/Parser/ParserSIVOP.cpp
+++ b/CodeXL/Components/ShaderAnalyzer/AMDTBackEnd/Emulator/Parser/ParserSIVOP.cpp
@@ -115,7 +115,8 @@ ParserSIVOP::GetInstructionType(Instruction::instruction32bit hexInstruction)
 VOPInstruction::Encoding
 ParserSIVOP::GetInstructionType(Instruction::instruction64bit hexInstruction)
 {
-    if ((hexInstruction && VOPInstruction::VOPMask_VOP3) >> 26 == VOPInstruction::Encoding_VOP3)
+    auto mask = VOPInstruction::VOPMask_VOP3 & 0xffffffffULL;
+    if ((hexInstruction & mask) >> 26 == VOPInstruction::Encoding_VOP3)
     {
         return VOPInstruction::Encoding_VOP3;
     }


### PR DESCRIPTION
GetInstructionType always returns invalid instruction for vop3 instructions,, so vop3 instruction decoding (for example, `v_cmp_ne_u32  vcc, s0, 0` -> `D18A006A 00010000`) fails.

Should I change the auto to uint64_t for non-c++11 compilers?