### PR TITLE
backend_build: path quoting, simplification, detect unset variables

### DIFF
--- a/CodeXL/Components/GpuProfiling/Build/backend_build.sh
+++ b/CodeXL/Components/GpuProfiling/Build/backend_build.sh
@@ -97,39 +97,39 @@ do
    shift
 done
 
-BUILD_PATH=$SPROOT/Build
+BUILD_PATH="$SPROOT/Build"
 
 echo "SPROOT=$SPROOT"
 
 if ($bLogFileSpecified) ; then
-   LOGFILE=$SPECIFIED_LOGFILE
+   LOGFILE="$SPECIFIED_LOGFILE"
 else
-   LOGFILE=$BUILD_PATH/GpuProfilerBackend_Build.log
+   LOGFILE="$BUILD_PATH/GpuProfilerBackend_Build.log"
 fi
 
-COMMON=$SPROOT/../../../Common
-CODEXL_DIR=$SPROOT/../../../CodeXL
-DOC=$SPROOT/Doc
-BIN=$SPROOT/bin
-BACKENDCOMMON=$SPROOT/Backend/Common
-BACKENDDEVICEINFO=$SPROOT/Backend/DeviceInfo
-CLCOMMON=$SPROOT/Backend/CLCommon
-SPROFILE=$SPROOT/Backend/sprofile
-PROFILER_OUTPUT=$SPROOT/Backend/CodeXLGpuProfiler
-CLPROFILE=$SPROOT/Backend/CLProfileAgent
-CLTRACE=$SPROOT/Backend/CLTraceAgent
-CLOCCUPANCY=$SPROOT/Backend/CLOccupancyAgent
-HSAFDNCOMMON=$SPROOT/Backend/HSAFdnCommon
-HSAFDNPMC=$SPROOT/Backend/HSAFdnPMC
-HSAFDNTRACE=$SPROOT/Backend/HSAFdnTrace
-PRELOADXINITTHREADS=$SPROOT/Backend/PreloadXInitThreads
-LINUXRESOURCES=$SPROOT/Backend/LinuxResources
-ACTIVITYLOGGER=CXLActivityLogger
-ACTIVITYLOGGERDIR=$SPROOT/../../../Common/Src/AMDTActivityLogger/
-GPA=$COMMON/Lib/AMD/GPUPerfAPI/2_20
-JQPLOT_PATH=$SPROOT/Backend/Common/jqPlot
-COMMONPROJECTS=$COMMON/Src/
-DOXYGENBIN=$COMMON/DK/Doxygen/doxygen-1.5.6/bin/doxygen
+COMMON="$SPROOT/../../../Common"
+CODEXL_DIR="$SPROOT/../../../CodeXL"
+DOC="$SPROOT/Doc"
+BIN="$SPROOT/bin"
+BACKENDCOMMON="$SPROOT/Backend/Common"
+BACKENDDEVICEINFO="$SPROOT/Backend/DeviceInfo"
+CLCOMMON="$SPROOT/Backend/CLCommon"
+SPROFILE="$SPROOT/Backend/sprofile"
+PROFILER_OUTPUT="$SPROOT/Backend/CodeXLGpuProfiler"
+CLPROFILE="$SPROOT/Backend/CLProfileAgent"
+CLTRACE="$SPROOT/Backend/CLTraceAgent"
+CLOCCUPANCY="$SPROOT/Backend/CLOccupancyAgent"
+HSAFDNCOMMON="$SPROOT/Backend/HSAFdnCommon"
+HSAFDNPMC="$SPROOT/Backend/HSAFdnPMC"
+HSAFDNTRACE="$SPROOT/Backend/HSAFdnTrace"
+PRELOADXINITTHREADS="$SPROOT/Backend/PreloadXInitThreads"
+LINUXRESOURCES="$SPROOT/Backend/LinuxResources"
+ACTIVITYLOGGER="CXLActivityLogger"
+ACTIVITYLOGGERDIR="$SPROOT/../../../Common/Src/AMDTActivityLogger/"
+GPA="$COMMON/Lib/AMD/GPUPerfAPI/2_20"
+JQPLOT_PATH="$SPROOT/Backend/Common/jqPlot"
+COMMONPROJECTS="$COMMON/Src/"
+DOXYGENBIN="$COMMON/DK/Doxygen/doxygen-1.5.6/bin/doxygen"
 
 GPACL=libGPUPerfAPICL.so
 GPACL32=libGPUPerfAPICL32.so
@@ -141,26 +141,26 @@ GPACOUNTER32=libGPUPerfAPICounters32.so
 
 GPU_PROFILER_LIB_PREFIX=CXLGpuProfiler
 
-COMMONLIB=lib${GPU_PROFILER_LIB_PREFIX}Common$DEBUG_SUFFIX.a
-COMMONLIB32=lib${GPU_PROFILER_LIB_PREFIX}Common32$DEBUG_SUFFIX.a
-CLCOMMONLIB=lib${GPU_PROFILER_LIB_PREFIX}CLCommon$DEBUG_SUFFIX.a
-CLCOMMONLIB32=lib${GPU_PROFILER_LIB_PREFIX}CLCommon32$DEBUG_SUFFIX.a
-HSACOMMONLIB=lib${GPU_PROFILER_LIB_PREFIX}HSACommon$DEBUG_SUFFIX.a
-DEVICEINFOLIB=lib${GPU_PROFILER_LIB_PREFIX}DeviceInfo$DEBUG_SUFFIX.a
-DEVICEINFOLIB32=lib${GPU_PROFILER_LIB_PREFIX}DeviceInfo32$DEBUG_SUFFIX.a
+COMMONLIB="lib${GPU_PROFILER_LIB_PREFIX}Common$DEBUG_SUFFIX.a"
+COMMONLIB32="lib${GPU_PROFILER_LIB_PREFIX}Common32$DEBUG_SUFFIX.a"
+CLCOMMONLIB="lib${GPU_PROFILER_LIB_PREFIX}CLCommon$DEBUG_SUFFIX.a"
+CLCOMMONLIB32="lib${GPU_PROFILER_LIB_PREFIX}CLCommon32$DEBUG_SUFFIX.a"
+HSACOMMONLIB="lib${GPU_PROFILER_LIB_PREFIX}HSACommon$DEBUG_SUFFIX.a"
+DEVICEINFOLIB="lib${GPU_PROFILER_LIB_PREFIX}DeviceInfo$DEBUG_SUFFIX.a"
+DEVICEINFOLIB32="lib${GPU_PROFILER_LIB_PREFIX}DeviceInfo32$DEBUG_SUFFIX.a"
 
-SPROFILEBIN=CodeXLGpuProfiler$DEBUG_SUFFIX
-SPROFILEBIN32=CodeXLGpuProfiler32$DEBUG_SUFFIX
-PROFILEBIN=lib${GPU_PROFILER_LIB_PREFIX}CLProfileAgent$DEBUG_SUFFIX.so
-PROFILEBIN32=lib${GPU_PROFILER_LIB_PREFIX}CLProfileAgent32$DEBUG_SUFFIX.so
-TRACEBIN=lib${GPU_PROFILER_LIB_PREFIX}CLTraceAgent$DEBUG_SUFFIX.so
-TRACEBIN32=lib${GPU_PROFILER_LIB_PREFIX}CLTraceAgent32$DEBUG_SUFFIX.so
-OCCUPANCYBIN=lib${GPU_PROFILER_LIB_PREFIX}CLOccupancyAgent$DEBUG_SUFFIX.so
-OCCUPANCYBIN32=lib${GPU_PROFILER_LIB_PREFIX}CLOccupancyAgent32$DEBUG_SUFFIX.so
-HSAPROFILEAGENTBIN=lib${GPU_PROFILER_LIB_PREFIX}HSAProfileAgent$DEBUG_SUFFIX.so
-HSATRACEAGENTBIN=lib${GPU_PROFILER_LIB_PREFIX}HSATraceAgent$DEBUG_SUFFIX.so
-PRELOADXINITTHREADSBIN=lib${GPU_PROFILER_LIB_PREFIX}PreloadXInitThreads$DEBUG_SUFFIX.so
-PRELOADXINITTHREADSBIN32=lib${GPU_PROFILER_LIB_PREFIX}PreloadXInitThreads32$DEBUG_SUFFIX.so
+SPROFILEBIN="CodeXLGpuProfiler$DEBUG_SUFFIX"
+SPROFILEBIN32="CodeXLGpuProfiler32$DEBUG_SUFFIX"
+PROFILEBIN="lib${GPU_PROFILER_LIB_PREFIX}CLProfileAgent$DEBUG_SUFFIX.so"
+PROFILEBIN32="lib${GPU_PROFILER_LIB_PREFIX}CLProfileAgent32$DEBUG_SUFFIX.so"
+TRACEBIN="lib${GPU_PROFILER_LIB_PREFIX}CLTraceAgent$DEBUG_SUFFIX.so"
+TRACEBIN32="lib${GPU_PROFILER_LIB_PREFIX}CLTraceAgent32$DEBUG_SUFFIX.so"
+OCCUPANCYBIN="lib${GPU_PROFILER_LIB_PREFIX}CLOccupancyAgent$DEBUG_SUFFIX.so"
+OCCUPANCYBIN32="lib${GPU_PROFILER_LIB_PREFIX}CLOccupancyAgent32$DEBUG_SUFFIX.so"
+HSAPROFILEAGENTBIN="lib${GPU_PROFILER_LIB_PREFIX}HSAProfileAgent$DEBUG_SUFFIX.so"
+HSATRACEAGENTBIN="lib${GPU_PROFILER_LIB_PREFIX}HSATraceAgent$DEBUG_SUFFIX.so"
+PRELOADXINITTHREADSBIN="lib${GPU_PROFILER_LIB_PREFIX}PreloadXInitThreads$DEBUG_SUFFIX.so"
+PRELOADXINITTHREADSBIN32="lib${GPU_PROFILER_LIB_PREFIX}PreloadXInitThreads32$DEBUG_SUFFIX.so"
 
 ACTIVITYLOGGERBIN=libCXLActivityLogger.so
 ACTIVITYLOGGERBIN32=libCXLActivityLogger.so
@@ -169,7 +169,7 @@ MAKE_TARGET_SUFFIX_X86=x86
 
 PRODUCTNAME=GPUProfilingBackend
 
-VERSION_FILE=$BACKENDCOMMON/Version.h
+VERSION_FILE="$BACKENDCOMMON/Version.h"
 
 DATE=$(date +"%Y-%m-%d")
 
@@ -179,15 +179,15 @@ VERSION="$VERSION_MAJOR.$VERSION_MINOR"
 VERSION_STR=$DATE-v$VERSION.$BUILD
 
 CODEXL_ARCHIVE_BASE=GPUProfilingBackendCodeXL-v$VERSION.$BUILD.tgz
-CODEXL_ARCHIVE=$BUILD_PATH/$CODEXL_ARCHIVE_BASE
+CODEXL_ARCHIVE="$BUILD_PATH/$CODEXL_ARCHIVE_BASE"
 
 if !($bZipOnly) ; then
    # delete log file
    if !($bAppendToLog) ; then
-      rm -f $LOGFILE
+      rm -f "$LOGFILE"
    fi
 
-   echo "=====Building GPU Profiler Backend======"  | tee -a $LOGFILE
+   echo "=====Building GPU Profiler Backend======"  | tee -a "$LOGFILE"
 
    if ($bBuildFramework) ; then
       #-----------------------------------------
@@ -202,58 +202,59 @@ if !($bZipOnly) ; then
       NUM_ERRORS=0
 
       # Display a start message:
-      echo | tee -a $LOGFILE
-      echo "Building infra projects" | tee -a $LOGFILE
-      echo "===========================" | tee -a $LOGFILE
-      echo "Build arguments passed to scons: $commandLineArgs" | tee -a $LOGFILE
+      echo | tee -a "$LOGFILE"
+      echo "Building infra projects" | tee -a "$LOGFILE"
+      echo "===========================" | tee -a "$LOGFILE"
+      echo "Build arguments passed to scons: $commandLineArgs" | tee -a "$LOGFILE"
+
       if [ "x${AMD_OUTPUT}x" = "xx" ]
       then
          # If not, it means this script was invoked by unknown means.
-         export AMD_OUTPUT_PROFILING=${SPROOT}/../
+         export AMD_OUTPUT_PROFILING="${SPROOT}/../"
       fi
-      export CXL_common_dir=${COMMON}
-      echo "========================================== " | tee -a $LOGFILE
-      echo "----------- Start building --------------- " | tee -a $LOGFILE
-      cd ${SPROOT}/Build
-      date | tee -a $LOGFILE
+      export CXL_common_dir="${COMMON}"
+      echo "========================================== " | tee -a "$LOGFILE"
+      echo "----------- Start building --------------- " | tee -a "$LOGFILE"
+      cd "${SPROOT}/Build"
+      date | tee -a "$LOGFILE"
 
       if ($bDebugBuild) ; then
-         echo "----------- Building debug version --------------- " | tee -a $LOGFILE
-         echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build=debug CXL_build_type=static $commandLineArgs" | tee -a $LOGFILE
-         eval "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build=debug CXL_build_type=static $commandLineArgs >> $LOGFILE 2>&1"
+         echo "----------- Building debug version --------------- " | tee -a "$LOGFILE"
+         echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build=debug CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
+         eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_build=debug CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
       else
          echo "========================================== " | tee -a $LOGFILE
-         echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build_type=static $commandLineArgs" | tee -a $LOGFILE
-         eval "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build_type=static $commandLineArgs >> $LOGFILE 2>&1"
+         echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
+         eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
       fi
       RC1=$?
       if [ ${RC1} -ne 0 ]
       then
-         echo "*** ERROR during the build of the 64 bit framework ***" | tee -a $LOGFILE
+         echo "*** ERROR during the build of the 64 bit framework ***" | tee -a "$LOGFILE"
       fi
 
       RC2=0
       if $b32bitbuild; then
          if ($bDebugBuild) ; then
-            echo "----------- Building debug 32-bit version --------------- " | tee -a $LOGFILE
-            echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build=debug CXL_build_type=static $commandLineArgs" | tee -a $LOGFILE
-            eval "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build=debug CXL_build_type=static $commandLineArgs >> $LOGFILE 2>&1"
+            echo "----------- Building debug 32-bit version --------------- " | tee -a "$LOGFILE"
+            echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build=debug CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
+            eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_arch=x86 CXL_build=debug CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
          else
             echo "========================================== " | tee -a $LOGFILE
-            echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build_type=static $commandLineArgs" | tee -a $LOGFILE
-            eval "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build_type=static $commandLineArgs >> $LOGFILE 2>&1"
+            echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
+            eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_arch=x86 CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
          fi
          RC2=$?
          if [ ${RC2} -ne 0 ]
          then
-            echo "*** ERROR during the build of the 32 bit framework ***" | tee -a $LOGFILE
+            echo "*** ERROR during the build of the 32 bit framework ***" | tee -a "$LOGFILE"
          fi
       fi
 
-      echo "========================================== " | tee -a $LOGFILE
-      echo "----------- End building ----------------- " | tee -a $LOGFILE
-      date | tee -a $LOGFILE
-      echo "========================================== " | tee -a $LOGFILE
+      echo "========================================== " | tee -a "$LOGFILE"
+      echo "----------- End building ----------------- " | tee -a "$LOGFILE"
+      date | tee -a "$LOGFILE"
+      echo "========================================== " | tee -a "$LOGFILE"
 
       NUM_ERRORS=`expr ${NUM_ERRORS} + ${RC1} + ${RC2}`
       if [ ${NUM_ERRORS} -ne 0 ]
@@ -269,8 +270,8 @@ if !($bZipOnly) ; then
       fi
 
       if ($bCleanOnly); then
-         rm -rf $SPROOT/Output_x86_64/
-         rm -rf $SPROOT/Output_x86/
+         rm -rf "$SPROOT/Output_x86_64/"
+         rm -rf "$SPROOT/Output_x86/"
       fi
    fi
 
@@ -278,27 +279,27 @@ if !($bZipOnly) ; then
    # Update Version.h to include build number
    #-----------------------------------------
    CURRENT_VERSION_H_FILE_PERMISSIONS=$(stat --format %a $VERSION_FILE)
-   chmod 777 $VERSION_FILE
+   chmod 777 "$VERSION_FILE"
    old=$(grep -E "#define GPUPROFILER_BACKEND_BUILD_NUMBER [0-9]+" $VERSION_FILE)
    new="#define GPUPROFILER_BACKEND_BUILD_NUMBER $BUILD"
-   sed -i "s/$old/$new/g" $VERSION_FILE
-   chmod $CURRENT_VERSION_H_FILE_PERMISSIONS $VERSION_FILE
+   sed -i "s/$old/$new/g" "$VERSION_FILE"
+   chmod $CURRENT_VERSION_H_FILE_PERMISSIONS "$VERSION_FILE"
 
-   cd $SPROFILE
+   cd "$SPROFILE"
 
    #delete old build if it exists
-   rm -f ./$SPROFILEBIN
-   rm -f ./$SPROFILEBIN32
-   rm -f ./$PROFILEBIN
-   rm -f ./$PROFILEBIN32
-   rm -f ./$TRACEBIN
-   rm -f ./$TRACEBIN32
-   rm -f ./$HSATRACEAGENTBIN
-   rm -f ./$HSAPROFILEAGENTBIN
-   rm -f ./$OCCUPANCYBIN
-   rm -f ./$OCCUPANCYBIN32
-   rm -f ./$PRELOADXINITTHREADSBIN
-   rm -f ./$PRELOADXINITTHREADSBIN32
+   rm -f "./$SPROFILEBIN"
+   rm -f "./$SPROFILEBIN32"
+   rm -f "./$PROFILEBIN"
+   rm -f "./$PROFILEBIN32"
+   rm -f "./$TRACEBIN"
+   rm -f "./$TRACEBIN32"
+   rm -f "./$HSATRACEAGENTBIN"
+   rm -f "./$HSAPROFILEAGENTBIN"
+   rm -f "./$OCCUPANCYBIN"
+   rm -f "./$OCCUPANCYBIN32"
+   rm -f "./$PRELOADXINITTHREADSBIN"
+   rm -f "./$PRELOADXINITTHREADSBIN32"
 
    BUILD_DIRS="$BACKENDCOMMON $BACKENDDEVICEINFO $CLCOMMON"
 
@@ -316,14 +317,14 @@ if !($bZipOnly) ; then
       BASENAME=`basename $SUBDIR`
 
       if !($bIncrementalBuild) ; then
-         make -C $SUBDIR spotless >> $LOGFILE 2>&1
+         make -C "$SUBDIR" spotless >> "$LOGFILE" 2>&1
       fi
 
       if !($bCleanOnly); then
          #make 64 bit
-         echo "Build ${BASENAME}, 64-bit..." | tee -a $LOGFILE
+         echo "Build ${BASENAME}, 64-bit..." | tee -a "$LOGFILE"
 
-         if ! make -C $SUBDIR -j$CPU_COUNT $HSA_DIR_OVERRIDE $MAKE_TARGET >> $LOGFILE 2>&1; then
+         if ! make -C "$SUBDIR" -j$CPU_COUNT $HSA_DIR_OVERRIDE $MAKE_TARGET >> "$LOGFILE" 2>&1; then
             echo "Failed to build ${BASENAME}, 64 bit"
             exit 1
          fi
@@ -338,9 +339,9 @@ if !($bZipOnly) ; then
             fi
 
             #make 32 bit
-            echo "Build ${BASENAME}, 32-bit..." | tee -a $LOGFILE
+            echo "Build ${BASENAME}, 32-bit..." | tee -a "$LOGFILE"
 
-            if ! make -C $SUBDIR -j$CPU_COUNT $HSA_DIR_OVERRIDE $MAKE_TARGET$MAKE_TARGET_SUFFIX_X86 >> $LOGFILE 2>&1; then
+            if ! make -C "$SUBDIR" -j$CPU_COUNT $HSA_DIR_OVERRIDE $MAKE_TARGET$MAKE_TARGET_SUFFIX_X86 >> "$LOGFILE" 2>&1; then
                echo "Failed to build ${BASENAME}, 32 bit"
                exit 1
             fi
@@ -349,175 +350,176 @@ if !($bZipOnly) ; then
    done
 
    if !($bCleanOnly); then
-      cp -f $GPA/Bin/Linx64/$GPACOUNTER $PROFILER_OUTPUT
-      cp -f $GPA/Bin/Linx86/$GPACOUNTER32 $PROFILER_OUTPUT
+      cp -f "$GPA/Bin/Linx64/$GPACOUNTER" "$PROFILER_OUTPUT"
+      cp -f "$GPA/Bin/Linx86/$GPACOUNTER32" "$PROFILER_OUTPUT"
 
       if $bBuildOCLProfiler ; then
-         cp -f $GPA/Bin/Linx64/$GPACL $PROFILER_OUTPUT
-         cp -f $GPA/Bin/Linx86/$GPACL32 $PROFILER_OUTPUT
+         cp -f "$GPA/Bin/Linx64/$GPACL" "$PROFILER_OUTPUT"
+         cp -f "$GPA/Bin/Linx86/$GPACL32" "$PROFILER_OUTPUT"
       fi
 
       if $bBuildHSAProfiler ; then
-         cp -f $GPA/Bin/Linx64/$GPAHSA $PROFILER_OUTPUT
+         cp -f "$GPA/Bin/Linx64/$GPAHSA" "$PROFILER_OUTPUT"
       fi
    else
-      rm -rf $PROFILER_OUTPUT
+      rm -rf "$PROFILER_OUTPUT"
    fi
 
    #-----------------------------------------
    #clean up bin folder
    #-----------------------------------------
-   rm -rf $BIN
+   rm -rf "$BIN"
 
    if !($bCleanOnly); then
       #-----------------------------------------
       #check if bin folder exist
       #-----------------------------------------
-      if [ ! -e $BIN ]; then
-         mkdir $BIN
+      if [ ! -e "$BIN" ]; then
+         mkdir "$BIN"
       fi
 
-      if [ ! -e $BIN/$ACTIVITYLOGGER ]; then
-         mkdir $BIN/$ACTIVITYLOGGER
+      if [ ! -e "$BIN/$ACTIVITYLOGGER" ]; then
+         mkdir "$BIN/$ACTIVITYLOGGER"
       fi
 
-      if [ ! -e $BIN/$ACTIVITYLOGGER/bin ]; then
-         mkdir $BIN/$ACTIVITYLOGGER/bin
+      if [ ! -e "$BIN/$ACTIVITYLOGGER/bin" ]; then
+         mkdir "$BIN/$ACTIVITYLOGGER/bin"
       fi
 
       if [ ! -e $BIN/$ACTIVITYLOGGER/doc ]; then
-         mkdir $BIN/$ACTIVITYLOGGER/doc
+         mkdir "$BIN/$ACTIVITYLOGGER/doc"
       fi
 
-      if [ ! -e $BIN/$ACTIVITYLOGGER/bin/x86 ]; then
-         mkdir $BIN/$ACTIVITYLOGGER/bin/x86
+      if [ ! -e "$BIN/$ACTIVITYLOGGER/bin/x86" ]; then
+         mkdir "$BIN/$ACTIVITYLOGGER/bin/x86"
       fi
 
-      if [ ! -e $BIN/$ACTIVITYLOGGER/bin/x86_64 ]; then
-         mkdir $BIN/$ACTIVITYLOGGER/bin/x86_64
+      if [ ! -e "$BIN/$ACTIVITYLOGGER/bin/x86_64" ]; then
+         mkdir "$BIN/$ACTIVITYLOGGER/bin/x86_64"
       fi
 
-      if [ ! -e $BIN/$ACTIVITYLOGGER/include ]; then
-         mkdir $BIN/$ACTIVITYLOGGER/include
+      if [ ! -e "$BIN/$ACTIVITYLOGGER/include" ]; then
+         mkdir "$BIN/$ACTIVITYLOGGER/include"
       fi
 
-      if [ ! -e $BIN/jqPlot ]; then
-         mkdir $BIN/jqPlot
+      if [ ! -e "$BIN/jqPlot" ]; then
+         mkdir "$BIN/jqPlot"
       fi
 
       #-----------------------------------------
       #copy to bin folder
       #-----------------------------------------
       # x64
-      cp $PROFILER_OUTPUT/$SPROFILEBIN $BIN/$SPROFILEBIN
-      cp $PROFILER_OUTPUT/$PRELOADXINITTHREADSBIN $BIN/$PRELOADXINITTHREADSBIN
+      cp "$PROFILER_OUTPUT/$SPROFILEBIN" "$BIN/$SPROFILEBIN"
+      cp "$PROFILER_OUTPUT/$PRELOADXINITTHREADSBIN" "$BIN/$PRELOADXINITTHREADSBIN"
       if $bBuildOCLProfiler ; then
-         cp $PROFILER_OUTPUT/$PROFILEBIN $BIN/$PROFILEBIN
-         cp $PROFILER_OUTPUT/$TRACEBIN $BIN/$TRACEBIN
-         cp $PROFILER_OUTPUT/$OCCUPANCYBIN $BIN/$OCCUPANCYBIN
-         cp $GPA/Bin/Linx64/$GPACL $BIN/$GPACL
+         cp "$PROFILER_OUTPUT/$PROFILEBIN" "$BIN/$PROFILEBIN"
+         cp "$PROFILER_OUTPUT/$TRACEBIN" "$BIN/$TRACEBIN"
+         cp "$PROFILER_OUTPUT/$OCCUPANCYBIN" "$BIN/$OCCUPANCYBIN"
+         cp "$GPA/Bin/Linx64/$GPACL" "$BIN/$GPACL"
       fi
       if $bBuildHSAProfiler ; then
-         cp $PROFILER_OUTPUT/$HSATRACEAGENTBIN $BIN/$HSATRACEAGENTBIN
-         cp $PROFILER_OUTPUT/$HSAPROFILEAGENTBIN $BIN/$HSAPROFILEAGENTBIN
-         cp $GPA/Bin/Linx64/$GPAHSA $BIN/$GPAHSA
+         cp "$PROFILER_OUTPUT/$HSATRACEAGENTBIN" "$BIN/$HSATRACEAGENTBIN
+         cp "$PROFILER_OUTPUT/$HSAPROFILEAGENTBIN" "$BIN/$HSAPROFILEAGENTBIN
+         cp "$GPA/Bin/Linx64/$GPAHSA" "$BIN/$GPAHSA"
       fi
-      cp $GPA/Bin/Linx64/$GPACOUNTER $BIN/$GPACOUNTER
-      cp $LINUXRESOURCES/CodeXLGpuProfilerRun $BIN
+      cp "$GPA/Bin/Linx64/$GPACOUNTER" "$BIN/$GPACOUNTER"
+      cp "$LINUXRESOURCES/CodeXLGpuProfilerRun" "$BIN"
 
       #x86
       if $b32bitbuild; then
          if $bBuildOCLProfiler ; then
-            cp $PROFILER_OUTPUT/$SPROFILEBIN32 $BIN/$SPROFILEBIN32
-            cp $PROFILER_OUTPUT/$PRELOADXINITTHREADSBIN32 $BIN/$PRELOADXINITTHREADSBIN32
-            cp $PROFILER_OUTPUT/$PROFILEBIN32 $BIN/$PROFILEBIN32
-            cp $PROFILER_OUTPUT/$TRACEBIN32 $BIN/$TRACEBIN32
-            cp $PROFILER_OUTPUT/$OCCUPANCYBIN32 $BIN/$OCCUPANCYBIN32
-            cp $GPA/Bin/Linx86/$GPACL32 $BIN/$GPACL32
-            cp $GPA/Bin/Linx86/$GPACOUNTER32 $BIN/$GPACOUNTER32
-            cp $LINUXRESOURCES/CodeXLGpuProfilerRun32 $BIN
+            cp "$PROFILER_OUTPUT/$SPROFILEBIN32" "$BIN/$SPROFILEBIN32"
+            cp "$PROFILER_OUTPUT/$PRELOADXINITTHREADSBIN32" "$BIN/$PRELOADXINITTHREADSBIN32"
+            cp "$PROFILER_OUTPUT/$PROFILEBIN32" "$BIN/$PROFILEBIN32"
+            cp "$PROFILER_OUTPUT/$TRACEBIN32" "$BIN/$TRACEBIN32"
+            cp "$PROFILER_OUTPUT/$OCCUPANCYBIN32" "$BIN/$OCCUPANCYBIN32"
+            cp "$GPA/Bin/Linx86/$GPACL32" "$BIN/$GPACL32"
+            cp "$GPA/Bin/Linx86/$GPACOUNTER32" "$BIN/$GPACOUNTER32"
+            cp "$LINUXRESOURCES/CodeXLGpuProfilerRun32" "$BIN"
          fi
       fi
 
       #AMDTActivityLogger files
-      cp $SPROOT/Output_x86_64/$CODEXL_FRAMEWORK_BUILD_CONFIG_DIR/bin/$ACTIVITYLOGGERBIN $BIN/$ACTIVITYLOGGER/bin/x86_64/$ACTIVITYLOGGERBIN
-      cp $SPROOT/Output_x86/$CODEXL_FRAMEWORK_BUILD_CONFIG_DIR/bin/$ACTIVITYLOGGERBIN32 $BIN/$ACTIVITYLOGGER/bin/x86/$ACTIVITYLOGGERBIN32
-      cp $ACTIVITYLOGGERDIR/AMDTActivityLogger.h $BIN/$ACTIVITYLOGGER/include/$ACTIVITYLOGGER.h
-      cp $ACTIVITYLOGGERDIR/Doc/AMDTActivityLogger.pdf $BIN/$ACTIVITYLOGGER/doc/AMDTActivityLogger.pdf
+      cp "$SPROOT/Output_x86_64/$CODEXL_FRAMEWORK_BUILD_CONFIG_DIR/bin/$ACTIVITYLOGGERBIN" "$BIN/$ACTIVITYLOGGER/bin/x86_64/$ACTIVITYLOGGERBIN"
+      $b32bitbuild && cp "$SPROOT/Output_x86/$CODEXL_FRAMEWORK_BUILD_CONFIG_DIR/bin/$ACTIVITYLOGGERBIN32" "$BIN/$ACTIVITYLOGGER/bin/x86/$ACTIVITYLOGGERBIN32"
+      cp "$ACTIVITYLOGGERDIR/AMDTActivityLogger.h" "$BIN/$ACTIVITYLOGGER/include/$ACTIVITYLOGGER.h"
+      cp "$ACTIVITYLOGGERDIR/Doc/AMDTActivityLogger.pdf" "$BIN/$ACTIVITYLOGGER/doc/AMDTActivityLogger.pdf"
       #jqPlot files
-      cp $JQPLOT_PATH/* $BIN/jqPlot
+      cp "$JQPLOT_PATH/"* "$BIN/jqPlot"
    fi
 fi
 
 #-----------------------------------------
 # Copy to CodeXL output location
 #-----------------------------------------
-CODEXLOUTPUT=$CODEXL_DIR/../Output_x86_64
-CODEXLOUTPUTREL=$CODEXLOUTPUT/release
-CODEXLOUTPUTDBG=$CODEXLOUTPUT/debug
+CODEXLOUTPUT="$CODEXL_DIR/../Output_x86_64"
+CODEXLOUTPUTREL="$CODEXLOUTPUT/release"
+CODEXLOUTPUTDBG="$CODEXLOUTPUT/debug"
 
-if [ -d $CODEXLOUTPUTREL ]; then
-   rm -rf $CODEXLOUTPUTREL/bin/$ACTIVITYLOGGER
-   rm -rf $CODEXLOUTPUTREL/bin/jqPlot
+if [ -d "$CODEXLOUTPUTREL" ]; then
+   rm -rf "$CODEXLOUTPUTREL/bin/$ACTIVITYLOGGER"
+   rm -rf "$CODEXLOUTPUTREL/bin/jqPlot"
 
    if !($bCleanOnly); then
-      echo "Copying GPU Profiler backend files to CodeXL Output release directory" | tee -a $LOGFILE
-      cp -R $BIN/$ACTIVITYLOGGER $CODEXLOUTPUTREL/bin
-      cp -R $BIN/jqPlot $CODEXLOUTPUTREL/bin
+      echo "Copying GPU Profiler backend files to CodeXL Output release directory" | tee -a "$LOGFILE"
 
-      cp -f $BIN/* $CODEXLOUTPUTREL/bin
+      cp -R "$BIN/$ACTIVITYLOGGER" "$CODEXLOUTPUTREL/bin"
+      cp -R "$BIN/jqPlot" "$CODEXLOUTPUTREL/bin"
+
+      cp -rf "$BIN/"* "$CODEXLOUTPUTREL/bin"
    fi
 fi
 
-if [ -d $CODEXLOUTPUTDBG ]; then
-   rm -rf $CODEXLOUTPUTDBG/bin/$ACTIVITYLOGGER
-   rm -rf $CODEXLOUTPUTDBG/bin/jqPlot
+if [ -d "$CODEXLOUTPUTDBG" ]; then
+   rm -rf "$CODEXLOUTPUTDBG/bin/$ACTIVITYLOGGER"
+   rm -rf "$CODEXLOUTPUTDBG/bin/jqPlot"
 
    if !($bCleanOnly); then
-      echo "Copying GPU Profiler backend files to CodeXL Output debug directory" | tee -a $LOGFILE
-      cp -R $BIN/$ACTIVITYLOGGER $CODEXLOUTPUTDBG/bin
-      cp -R $BIN/jqPlot $CODEXLOUTPUTDBG/bin
+      echo "Copying GPU Profiler backend files to CodeXL Output debug directory" | tee -a "$LOGFILE"
+      cp -R "$BIN/$ACTIVITYLOGGER" "$CODEXLOUTPUTDBG/bin"
+      cp -R "$BIN/jqPlot" "$CODEXLOUTPUTDBG/bin"
 
-      cp -f $BIN/* $CODEXLOUTPUTDBG/bin
+      cp -rf "$BIN/"* "$CODEXLOUTPUTDBG/bin"
    fi
 fi
 
-cd $BUILD_PATH
+cd "$BUILD_PATH"
 rm -f ./*.tgz
 
 #-----------------------------------------
 # zip
 #-----------------------------------------
 if $bZip || $bZipOnly ; then
-   cd $BUILD_PATH
+   cd "$BUILD_PATH"
    rm -f ./*.tgz
 
    # pack x64 version
-   echo "Creating public build tarball..." | tee -a $LOGFILE
-   if [ ! -e $BUILD_PATH/$PRODUCTNAME-$VERSION ]; then
-      mkdir $BUILD_PATH/$PRODUCTNAME-$VERSION
-      mkdir $BUILD_PATH/$PRODUCTNAME-$VERSION/bin
+   echo "Creating public build tarball..." | tee -a "$LOGFILE"
+   if [ ! -e "$BUILD_PATH/$PRODUCTNAME-$VERSION" ]; then
+      mkdir "$BUILD_PATH/$PRODUCTNAME-$VERSION"
+      mkdir "$BUILD_PATH/$PRODUCTNAME-$VERSION/bin"
    fi
 
-   cp $BIN/* $BUILD_PATH/$PRODUCTNAME-$VERSION/bin
-   cp -R $BIN/$ACTIVITYLOGGER $BUILD_PATH/$PRODUCTNAME-$VERSION
-   cp -R $BIN/jqPlot $BUILD_PATH/$PRODUCTNAME-$VERSION
-   chmod -R 755 $BUILD_PATH/$PRODUCTNAME-$VERSION
+   cp "$BIN/"* "$BUILD_PATH/$PRODUCTNAME-$VERSION/bin"
+   cp -R "$BIN/$ACTIVITYLOGGER" "$BUILD_PATH/$PRODUCTNAME-$VERSION"
+   cp -R "$BIN/jqPlot" "$BUILD_PATH/$PRODUCTNAME-$VERSION"
+   chmod -R 755 "$BUILD_PATH/$PRODUCTNAME-$VERSION"
 
    # create artifact for CodeXL
-   cd $BUILD_PATH/$PRODUCTNAME-$VERSION
-   tar cvzf $CODEXL_ARCHIVE bin/ jqPlot/ $ACTIVITYLOGGER/
-   chmod 755 $CODEXL_ARCHIVE
-   cd $BUILD_PATH
+   cd "$BUILD_PATH/$PRODUCTNAME-$VERSION"
+   tar cvzf "$CODEXL_ARCHIVE" bin/ jqPlot/ "$ACTIVITYLOGGER/"
+   chmod 755 "$CODEXL_ARCHIVE"
+   cd "$BUILD_PATH"
 
    # cleanup
-   rm -rf $BUILD_PATH/$PRODUCTNAME-$VERSION/
+   rm -rf "$BUILD_PATH/$PRODUCTNAME-$VERSION/"
 
    # Check artifacts, write to log.
-   if [ -e $CODEXL_ARCHIVE ] ; then
+   if [ -e "$CODEXL_ARCHIVE" ] ; then
       echo "$CODEXL_ARCHIVE_BASE" >> $LOGFILE
    else
-      echo "Failed to generate $CODEXL_ARCHIVE" >> $LOGFILE
+      echo "Failed to generate $CODEXL_ARCHIVE" >> "$LOGFILE"
       exit 1
    fi
 fi

--- a/CodeXL/Components/GpuProfiling/Build/backend_build.sh
+++ b/CodeXL/Components/GpuProfiling/Build/backend_build.sh
@@ -31,6 +31,9 @@ BUILD=0
 # Incremental build
 bIncrementalBuild=false
 
+# Estimate the number of processors we have. This will only work under Linux unfortunately.
+CPU_COUNT=${CPU_COUNT:-$(grep -c ^processor /proc/cpuinfo)}
+
 # Append to existing log file
 bAppendToLog=false
 

--- a/CodeXL/Components/GpuProfiling/Build/backend_build.sh
+++ b/CodeXL/Components/GpuProfiling/Build/backend_build.sh
@@ -207,7 +207,7 @@ if !($bZipOnly) ; then
       echo "===========================" | tee -a "$LOGFILE"
       echo "Build arguments passed to scons: $commandLineArgs" | tee -a "$LOGFILE"
 
-      if [ "x${AMD_OUTPUT}x" = "xx" ]
+      if [ -z ${AMD_OUTPUT+x} ]
       then
          # If not, it means this script was invoked by unknown means.
          export AMD_OUTPUT_PROFILING="${SPROOT}/../"

--- a/CodeXL/Components/GpuProfiling/Build/backend_build.sh
+++ b/CodeXL/Components/GpuProfiling/Build/backend_build.sh
@@ -225,12 +225,12 @@ if !($bZipOnly) ; then
 
       if ($bDebugBuild) ; then
          echo "----------- Building debug version --------------- " | tee -a "$LOGFILE"
-         echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build=debug CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
-         eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_build=debug CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
+         echo "scons -C "${SPROOT}/Build" CXL_prefix="${SPROOT}" CXL_build=debug CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
+         (scons -C "${SPROOT}/Build" CXL_prefix="${SPROOT}" CXL_build=debug CXL_build_type=static $commandLineArgs) >> "$LOGFILE" 2>&1
       else
          echo "========================================== " | tee -a $LOGFILE
-         echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
-         eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
+         echo "scons -C "${SPROOT}/Build" CXL_prefix="${SPROOT}" CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
+         (scons -C "${SPROOT}/Build" CXL_prefix="${SPROOT}" CXL_build_type=static $commandLineArgs) >> "$LOGFILE" 2>&1
       fi
       RC1=$?
       if [ ${RC1} -ne 0 ]
@@ -243,11 +243,11 @@ if !($bZipOnly) ; then
          if ($bDebugBuild) ; then
             echo "----------- Building debug 32-bit version --------------- " | tee -a "$LOGFILE"
             echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build=debug CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
-            eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_arch=x86 CXL_build=debug CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
+            (scons -C "${SPROOT}/Build" CXL_prefix="${SPROOT}" CXL_arch=x86 CXL_build=debug CXL_build_type=static $commandLineArgs) >> "$LOGFILE" 2>&1
          else
             echo "========================================== " | tee -a $LOGFILE
-            echo "scons -C ${SPROOT}/Build CXL_prefix=${SPROOT} CXL_arch=x86 CXL_build_type=static $commandLineArgs" | tee -a "$LOGFILE"
-            eval "scons -C \"${SPROOT}/Build\" CXL_prefix=\"${SPROOT}\" CXL_arch=x86 CXL_build_type=static $commandLineArgs >> \"$LOGFILE\" 2>&1"
+            echo "(scons -C "${SPROOT}/Build" CXL_prefix="${SPROOT}" CXL_arch=x86 CXL_build_type=static $commandLineArgs)" | tee -a "$LOGFILE"
+            (scons -C "${SPROOT}/Build" CXL_prefix="${SPROOT}" CXL_arch=x86 CXL_build_type=static $commandLineArgs) >> "$LOGFILE" 2>&1
          fi
          RC2=$?
          if [ ${RC2} -ne 0 ]

--- a/CodeXL/Components/GpuProfiling/Build/backend_build.sh
+++ b/CodeXL/Components/GpuProfiling/Build/backend_build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -u
+
 #define path
 SPROOT=`dirname $(readlink -f "$0")`/..
 

--- a/CodeXL/Components/GpuProfiling/Build/backend_build.sh
+++ b/CodeXL/Components/GpuProfiling/Build/backend_build.sh
@@ -379,37 +379,14 @@ if !($bZipOnly) ; then
       #-----------------------------------------
       #check if bin folder exist
       #-----------------------------------------
-      if [ ! -e "$BIN" ]; then
-         mkdir "$BIN"
-      fi
-
-      if [ ! -e "$BIN/$ACTIVITYLOGGER" ]; then
-         mkdir "$BIN/$ACTIVITYLOGGER"
-      fi
-
-      if [ ! -e "$BIN/$ACTIVITYLOGGER/bin" ]; then
-         mkdir "$BIN/$ACTIVITYLOGGER/bin"
-      fi
-
-      if [ ! -e $BIN/$ACTIVITYLOGGER/doc ]; then
-         mkdir "$BIN/$ACTIVITYLOGGER/doc"
-      fi
-
-      if [ ! -e "$BIN/$ACTIVITYLOGGER/bin/x86" ]; then
-         mkdir "$BIN/$ACTIVITYLOGGER/bin/x86"
-      fi
-
-      if [ ! -e "$BIN/$ACTIVITYLOGGER/bin/x86_64" ]; then
-         mkdir "$BIN/$ACTIVITYLOGGER/bin/x86_64"
-      fi
-
-      if [ ! -e "$BIN/$ACTIVITYLOGGER/include" ]; then
-         mkdir "$BIN/$ACTIVITYLOGGER/include"
-      fi
-
-      if [ ! -e "$BIN/jqPlot" ]; then
-         mkdir "$BIN/jqPlot"
-      fi
+      mkdir -p "$BIN"
+      mkdir -p "$BIN/$ACTIVITYLOGGER"
+      mkdir -p "$BIN/$ACTIVITYLOGGER/bin"
+      mkdir -p "$BIN/$ACTIVITYLOGGER/doc"
+      mkdir -p "$BIN/$ACTIVITYLOGGER/bin/x86"
+      mkdir -p "$BIN/$ACTIVITYLOGGER/bin/x86_64"
+      mkdir -p "$BIN/$ACTIVITYLOGGER/include"
+      mkdir -p "$BIN/jqPlot"
 
       #-----------------------------------------
       #copy to bin folder
@@ -501,10 +478,7 @@ if $bZip || $bZipOnly ; then
 
    # pack x64 version
    echo "Creating public build tarball..." | tee -a "$LOGFILE"
-   if [ ! -e "$BUILD_PATH/$PRODUCTNAME-$VERSION" ]; then
-      mkdir "$BUILD_PATH/$PRODUCTNAME-$VERSION"
-      mkdir "$BUILD_PATH/$PRODUCTNAME-$VERSION/bin"
-   fi
+   mkdir -p "$BUILD_PATH/$PRODUCTNAME-$VERSION/bin"
 
    cp "$BIN/"* "$BUILD_PATH/$PRODUCTNAME-$VERSION/bin"
    cp -R "$BIN/$ACTIVITYLOGGER" "$BUILD_PATH/$PRODUCTNAME-$VERSION"


### PR DESCRIPTION
* Attempt to quote paths to defend against errant spaces.
* Fix use of unset variables and then enable error detection for this
* Simplify a few `test`/`mkdir` pairs by using `mkdir -p`