### PR TITLE
WebServer: fix misleading cleanup under RemoveHandlers

### DIFF
--- a/CodeXL/Components/Graphics/Server/WebServer/OSDependent.cpp
+++ b/CodeXL/Components/Graphics/Server/WebServer/OSDependent.cpp
@@ -1089,7 +1089,7 @@ public:
     void RemoveHandlers()
     {
         std::map<int, SignalData>::iterator it;
-        for (it = m_signalMap.begin(); it != m_signalMap.end(); ++it);
+        for (it = m_signalMap.begin(); it != m_signalMap.end(); ++it)
         {
             sigaction(it->first, &(it->second.old_action), nullptr);
         }


### PR DESCRIPTION
The RemoveHandlers implementation had a terminating ';'
which would not allow the cleanup of the whole signal
map.

Signed-off-by: Awais Belal <awais_belal@mentor.com>