### PR TITLE
Fix build issues with gcc6

### DIFF
--- a/CodeXL/Components/GpuProfiling/Build/Common.mk
+++ b/CodeXL/Components/GpuProfiling/Build/Common.mk
@@ -8,7 +8,7 @@ PLATFORM_CFLAG =
 PLATFORM_LFLAG =
 TARGET_SUFFIX =
 ADDL_CFLAGS =
-CFLAGS = $(OPTIMIZE) -std=c++11 -fPIC -Wall -Wno-unknown-pragmas -Wno-strict-aliasing -Wno-non-virtual-dtor -Wno-conversion-null -Werror -msse $(PLATFORM_CFLAG) $(ADDL_CFLAGS)
+CFLAGS = $(OPTIMIZE) -std=c++11 -fPIC -Wall -Wno-unknown-pragmas -Wno-strict-aliasing -Wno-non-virtual-dtor -Wno-conversion-null -Wno-ignored-attributes -Werror -msse $(PLATFORM_CFLAG) $(ADDL_CFLAGS)
 HSAFDN_CFLAGS =
 PLATFORM_DIR = x64
 HSA_PLATFORM_DIR = x86_64

--- a/CodeXL/Components/PowerProfiling/Backend/AMDTPowerProfileAPI/src/AMDTPowerProfileApi.cpp
+++ b/CodeXL/Components/PowerProfiling/Backend/AMDTPowerProfileAPI/src/AMDTPowerProfileApi.cpp
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <math.h>
 void __attribute__((constructor)) initPowerProfileDriverInterface(void);
 void __attribute__((destructor))  finiPowerProfileDriverInterface(void);
 
@@ -761,7 +762,7 @@ AMDTUInt32 PwrGetCoreMask()
 
     if (PROFILE_TYPE_PROCESS_PROFILING == g_profileType)
     {
-        mask = ~0 ^ (~0 << g_sysInfo.m_coreCnt);
+        mask = ~((AMDTUInt32)0) ^ (~((AMDTUInt32)0) << g_sysInfo.m_coreCnt);
     }
     else
     {


### PR DESCRIPTION
This fixes build issues that are seen with gcc6 for AMDTPowerProfileAPI and GpuProfiling components.